### PR TITLE
Update NoLockScreen to affect resume only.

### DIFF
--- a/NoLockScreen/CMakeLists.txt
+++ b/NoLockScreen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   if(DEFINED ENV{VITASDK})
@@ -19,7 +19,7 @@ add_executable(nolockscreen
 )
 
 target_link_libraries(nolockscreen
-  taiHEN_stub
+  taihen_stub
 )
 
 vita_create_self(nolockscreen.suprx nolockscreen CONFIG exports.yml UNSAFE)

--- a/NoLockScreen/main.c
+++ b/NoLockScreen/main.c
@@ -19,7 +19,7 @@
 #include <psp2/kernel/modulemgr.h>
 #include <taihen.h>
 
-static SceUID hooks[2];
+static SceUID hookid = -1;
 
 void _start() __attribute__ ((weak, alias("module_start")));
 int module_start(SceSize args, void *argp) {
@@ -30,18 +30,15 @@ int module_start(SceSize args, void *argp) {
 
     switch (info.module_nid) {
       case 0x0552F692: // 3.60 retail
-        hooks[0] = taiInjectData(info.modid, 0, 0x2354D2, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
-        hooks[1] = taiInjectData(info.modid, 0, 0x2361D2, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
+        hookid = taiInjectData(info.modid, 0, 0x2361D2, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
         break;
 
       case 0x6CB01295: // 3.60 PDEL
-        hooks[0] = -1;
-        hooks[1] = taiInjectData(info.modid, 0, 0x229BF0, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
+        hookid = taiInjectData(info.modid, 0, 0x229BF0, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
         break;
       
       case 0xEAB89D5C: // 3.60 PTEL
-        hooks[0] = taiInjectData(info.modid, 0, 0x22D906, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
-        hooks[1] = taiInjectData(info.modid, 0, 0x22E606, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
+        hookid = taiInjectData(info.modid, 0, 0x22E606, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
         break;
 
       case 0x5549BF1F: // 3.65 retail
@@ -52,18 +49,15 @@ int module_start(SceSize args, void *argp) {
       case 0xF476E785: // 3.71 retail
       case 0x939FFBE9: // 3.72 retail
       case 0x734D476A: // 3.73 retail
-        hooks[0] = taiInjectData(info.modid, 0, 0x23556E, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
-        hooks[1] = taiInjectData(info.modid, 0, 0x23626E, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
+        hookid = taiInjectData(info.modid, 0, 0x23626E, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
         break;
 
       case 0xE6A02F2B: // 3.65 PDEL
-        hooks[0] = -1;
-        hooks[1] = taiInjectData(info.modid, 0, 0x229C8C, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
+        hookid = taiInjectData(info.modid, 0, 0x229C8C, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
         break;
 
       case 0x587F9CED: // 3.65 PTEL
-        hooks[0] = taiInjectData(info.modid, 0, 0x22D9A2, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
-        hooks[1] = taiInjectData(info.modid, 0, 0x22E6A2, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
+        hookid = taiInjectData(info.modid, 0, 0x22E6A2, &movs_a1_1_nop_opcode, sizeof(movs_a1_1_nop_opcode));
         break;
     }
   }
@@ -72,10 +66,8 @@ int module_start(SceSize args, void *argp) {
 }
 
 int module_stop(SceSize args, void *argp) {
-  if (hooks[1] >= 0)
-    taiInjectRelease(hooks[1]);
-  if (hooks[0] >= 0)
-    taiInjectRelease(hooks[0]);
+  if (hookid >= 0)
+    taiInjectRelease(hookid);
 
   return SCE_KERNEL_STOP_SUCCESS;
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # VitaTweaks
 
+> **Fork note:** NoLockScreen modified to only suppress the lock screen 
+> on resume from sleep, not on cold boot. See original repo for the 
+> unmodified version.
+> This was done to avoid a conflict with AutoBoot
+
 A collection of small tweaks for the PS Vita
 
 ## 1. NoLockScreen


### PR DESCRIPTION
The reason for this change is I was finding if I used NoLockScreen at the same time as AutoBoot, there was a full second on bootup of the bubbles live area before the chosen app booted. With the lock screen, even if unlocking right away, it always went straight into the app.
My solution was to make a version of nolockscreen.suprx that only affects the sleep resume lockscreen and leave the initial boot alone.

Also fixed a case sensitivity bug in CMakeList which causes it to not find the package when run on linux.