### PR TITLE
Fix CMakeLists.txt for use on linux systems.

### DIFF
--- a/NoLockScreen/CMakeLists.txt
+++ b/NoLockScreen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   if(DEFINED ENV{VITASDK})
@@ -19,7 +19,7 @@ add_executable(nolockscreen
 )
 
 target_link_libraries(nolockscreen
-  taiHEN_stub
+  taihen_stub
 )
 
 vita_create_self(nolockscreen.suprx nolockscreen CONFIG exports.yml UNSAFE)


### PR DESCRIPTION
CMakeLists.txt references taiHEN_stub but VitaSDK installs the library as taihen_stub (all lowercase). On Windows this works fine since the filesystem is case-insensitive, but on Linux it causes a build failure:
```
$ make
[ 25%] Linking C executable nolockscreen
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/15.2.0/../../../../arm-vita-eabi/bin/ld: cannot find -ltaiHEN_stub: No such file or directory
collect2: error: ld returned 1 exit status
```
This is solved by making the required name all lowercase to match the actual library name.

Also bumped cmake_minimum_required from its current value to 3.5, which is required to build with modern CMake versions.